### PR TITLE
Request: Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
+## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+os:
+  - linux
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
+  - 0.7
   - nightly
+matrix:
+  allow_failures:
+  - julia: 0.7
+  - julia: nightly
 notifications:
   email: false
+git:
+  depth: 99999999
+
 #script: # use the default script which also does a git fetch --unshallow
 #  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Jacobi")'
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'cd(Pkg.dir("Jacobi")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+  - julia -e 'cd(Pkg.dir("Jacobi")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jacobi
 
+[![Build Status](https://travis-ci.org/pjabardo/Jacobi.jl.png)](https://travis-ci.org/pjabardo/Jacobi.jl)
+
 A library that implements Jacobi polynomials and Gauss 
 quadrature related operations.
 
@@ -146,8 +148,3 @@ This package was implemented using both references below.
 
  * Spectral/hp Element Methods for CFD, 2nd edition, Karniadakis and Sherwin, 2005.
  * NIST Handbook of Mathematical Functions (http://dlmf.nist.gov/18)
-
-
-
-
-[![Build Status](https://travis-ci.org/pjabardo/Jacobi.jl.png)](https://travis-ci.org/pjabardo/Jacobi.jl)


### PR DESCRIPTION
It would be really nice to have CI up and running.  This project may be already in a stable state where you don't see more change to be made.  But for users, it is nice to know if the package is tested and the environment in which it is tested (e.g., Julia version).  Travis CI will record everything so anybody can have a look at it.

I did some tweaks to modernize `.travis.yml` so all you need to do is to login to Travis CI and enable it as in documented here:

> To get started with Travis CI #
>
> 1. Using your GitHub account, sign in to GitHub and add the Travis CI app to the repository you want to activate. You’ll need Admin permissions for that repository.
> 2. Once you’re signed in to Travis CI, and we’ve synchronized your GitHub repositories, go to your profile page and enable the repository you want to build: enable button ![](https://docs.travis-ci.com/images/enable.png)
>
> --- https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI

It would be nice to enable Travis before pulling this patch since I can check if it works by re-pushing this PR.
