### PR TITLE
Create .gitattributes to fix GitHub Languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+notebooks/*.ipynb linguist-generated


### PR DESCRIPTION
The package currently shows Jupyter Notebook 93.1%, Julia 6.9%. This PR marks the `notebooks/*.ipynb` files in such a way that they do not count towards the language summary.