### PR TITLE
bump compat for Polynomials to include v3 and v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Jacobi"
 uuid = "83f21c0b-4282-5fbc-9e3f-f6da3d2e584c"
 authors = ["Paulo José Saiz Jabardo <pjabardo@gmail.com> and contributors"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Polynomials = "1, 2"
+Polynomials = "1, 2, 3, 4"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 1.1, 1.2, 1.3, 2"
 julia = "^1"
 


### PR DESCRIPTION
IIUC with Polynomials stuck on v2 we suffer from a lot of invalidations caused by https://github.com/invenia/Intervals.jl/issues/144

Polynomials has dropped the Intervals.jl dependency some time around v3, so this should fix it.